### PR TITLE
fix: account for multiple headings with the same text

### DIFF
--- a/packages/starlight-links-validator/libs/remark.ts
+++ b/packages/starlight-links-validator/libs/remark.ts
@@ -2,7 +2,7 @@ import 'mdast-util-mdx-jsx'
 
 import nodePath from 'node:path'
 
-import { slug } from 'github-slugger'
+import GitHubSlugger, { slug } from 'github-slugger'
 import type { Nodes } from 'hast'
 import { fromHtml } from 'hast-util-from-html'
 import { hasProperty } from 'hast-util-has-property'
@@ -19,6 +19,7 @@ const links: Links = new Map()
 
 export const remarkStarlightLinksValidator: Plugin<[], Root> = function () {
   return (tree, file) => {
+    const slugger = new GitHubSlugger();
     const filePath = normalizeFilePath(file.history[0])
 
     const fileHeadings: string[] = []
@@ -35,7 +36,7 @@ export const remarkStarlightLinksValidator: Plugin<[], Root> = function () {
             break
           }
 
-          fileHeadings.push(slug(content))
+          fileHeadings.push(slugger.slug(content))
 
           break
         }

--- a/packages/starlight-links-validator/libs/remark.ts
+++ b/packages/starlight-links-validator/libs/remark.ts
@@ -19,7 +19,7 @@ const links: Links = new Map()
 
 export const remarkStarlightLinksValidator: Plugin<[], Root> = function () {
   return (tree, file) => {
-    const slugger = new GitHubSlugger();
+    const slugger = new GitHubSlugger()
     const filePath = normalizeFilePath(file.history[0])
 
     const fileHeadings: string[] = []

--- a/packages/starlight-links-validator/tests/fixtures/with-valid-links/src/content/docs/index.md
+++ b/packages/starlight-links-validator/tests/fixtures/with-valid-links/src/content/docs/index.md
@@ -14,6 +14,8 @@ title: Index
 - [Test page with hash](/test#title)
 - [Test page with hash](/test/#title)
 
+- [Test page with duplicated hash](/test#title-1)
+
 - [An MDX nested page](/guides/example)
 - [An MDX nested page](/guides/example/)
 

--- a/packages/starlight-links-validator/tests/fixtures/with-valid-links/src/content/docs/test.md
+++ b/packages/starlight-links-validator/tests/fixtures/with-valid-links/src/content/docs/test.md
@@ -21,3 +21,7 @@ some content
     test
   </a>
 </div>
+
+## Title
+
+More content.


### PR DESCRIPTION


**Describe the pull request**

This PR updates the code generating the ID for Markdown headings to use `github-slugger`’s stateful default export, creating an instance for each file.

**Why**

Fixes #11

Ensures headings with the same text each get a unique slug.

**How**

By importing `github-slugger`’s default export and instantiating it inside the remark file processor.

**Screenshots**

n/a
