### PR TITLE
fix: file path normalization on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,11 @@ on:
 jobs:
   lint_test:
     name: Lint & Test
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -35,8 +39,8 @@ jobs:
         run: pnpm astro sync
         working-directory: example
 
-      - name: Lint
-        run: pnpm lint
-
       - name: Test
         run: pnpm test
+
+      - name: Lint
+        run: pnpm lint

--- a/packages/starlight-links-validator/libs/remark.ts
+++ b/packages/starlight-links-validator/libs/remark.ts
@@ -130,7 +130,7 @@ function normalizeFilePath(filePath?: string) {
     .replace(/\.\w+$/, '')
     .replace(/index$/, '')
     .replace(/\/?$/, '/')
-    .split('/')
+    .split(/[/\\]/)
     .map((segment) => slug(segment))
     .join('/')
 }

--- a/packages/starlight-links-validator/vitest.config.ts
+++ b/packages/starlight-links-validator/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    testTimeout: 15_000,
+    testTimeout: 30_000,
   },
 })


### PR DESCRIPTION
**Describe the pull request**

Fix file path normalization on Windows.

Added `windows-latest` to the Lint & Test workflow to test on Windows. `strategy.fail-fast` is set to `false` because currently the run time is pretty short (less than 2 minutes), and when some tests are failing on one OS it's helpful to know whether they are failing on the other OS too.
Test is moved before Lint to have a faster feedback loop for functionality regardless if the code is formatted correctly.

Fix #13 

**Why**

link validation was not working on Windows.

**How**

Instead of only splitting the path by `/`, it now split paths by `/` or `\`.

**Screenshots**

_N/A_