### PR TITLE
Only trim trailing index from links if it is the full segment

### DIFF
--- a/.changeset/wicked-trains-call.md
+++ b/.changeset/wicked-trains-call.md
@@ -2,4 +2,4 @@
 "starlight-links-validator": patch
 ---
 
-Only trim trailing index from links if  it is the full segment
+Fixes validation issues for pages ending in `index`, e.g. `module_index`.

--- a/.changeset/wicked-trains-call.md
+++ b/.changeset/wicked-trains-call.md
@@ -1,0 +1,6 @@
+---
+"starlight-links-validator": patch
+"@starlight-links-validator-tests/valid-links": patch
+---
+
+fix: dont strip trailing index from links unless it is the full segment

--- a/.changeset/wicked-trains-call.md
+++ b/.changeset/wicked-trains-call.md
@@ -1,6 +1,5 @@
 ---
 "starlight-links-validator": patch
-"@starlight-links-validator-tests/valid-links": patch
 ---
 
-fix: dont strip trailing index from links unless it is the full segment
+Only trim trailing index from links if  it is the full segment

--- a/packages/starlight-links-validator/libs/remark.ts
+++ b/packages/starlight-links-validator/libs/remark.ts
@@ -178,7 +178,7 @@ function normalizeFilePath(base: string, srcDir: URL, filePath?: string) {
   const path = nodePath
     .relative(nodePath.join(fileURLToPath(srcDir), 'content/docs'), filePath)
     .replace(/\.\w+$/, '')
-    .replace(/index$/, '')
+    .replace(/(^|[/\\])index$/, '')
     .replace(/[/\\]?$/, '/')
     .split(/[/\\]/)
     .map((segment) => slug(segment))

--- a/packages/starlight-links-validator/tests/fixtures/valid-links/src/content/docs/a-page-that-ends-with-index.md
+++ b/packages/starlight-links-validator/tests/fixtures/valid-links/src/content/docs/a-page-that-ends-with-index.md
@@ -1,0 +1,5 @@
+---
+title: A page that ends with index
+---
+
+Content

--- a/packages/starlight-links-validator/tests/fixtures/valid-links/src/content/docs/index.md
+++ b/packages/starlight-links-validator/tests/fixtures/valid-links/src/content/docs/index.md
@@ -19,6 +19,8 @@ title: Index
 - [An MDX nested page](/guides/example)
 - [An MDX nested page](/guides/example/)
 
+- [A page that ends with index](/a-page-that-ends-with-index)
+
 # More links
 
 - [Link to hash in this page](#some-links)


### PR DESCRIPTION
Previously the replacement `replace(/index$/, '')` was called when normalizing file paths which would result in links like `/packages/spec/module_index` to be listed as invalid because it would get normalized to `/packages/spec/module_`.

This PR fixes that by only replacing `index` at the end of a file path if it is the full segment.