### PR TITLE
Fix missing dependency

### DIFF
--- a/.changeset/gorgeous-plums-sleep.md
+++ b/.changeset/gorgeous-plums-sleep.md
@@ -1,0 +1,5 @@
+---
+'starlight-links-validator': patch
+---
+
+Add `mdast-util-mdx-jsx` as a dependency to prevent issues in monorepos with hoisting disabled.

--- a/.changeset/gorgeous-plums-sleep.md
+++ b/.changeset/gorgeous-plums-sleep.md
@@ -2,4 +2,4 @@
 'starlight-links-validator': patch
 ---
 
-Add `mdast-util-mdx-jsx` as a dependency to prevent issues in monorepos with hoisting disabled.
+Moves `mdast-util-mdx-jsx` package to non-dev dependencies to prevent issues in monorepos with hoisting disabled.

--- a/packages/starlight-links-validator/package.json
+++ b/packages/starlight-links-validator/package.json
@@ -20,6 +20,7 @@
     "hast-util-has-property": "^3.0.0",
     "is-absolute-url": "^4.0.1",
     "kleur": "^4.1.5",
+    "mdast-util-mdx-jsx": "^3.1.3",
     "mdast-util-to-string": "^4.0.0",
     "picomatch": "^4.0.2",
     "unist-util-visit": "^5.0.0"
@@ -28,7 +29,6 @@
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
     "@types/node": "^18.19.68",
-    "mdast-util-mdx-jsx": "^3.1.3",
     "remark-custom-heading-id": "^2.0.0",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      mdast-util-mdx-jsx:
+        specifier: ^3.1.3
+        version: 3.1.3
       mdast-util-to-string:
         specifier: ^4.0.0
         version: 4.0.0
@@ -111,9 +114,6 @@ importers:
       '@types/node':
         specifier: ^18.19.68
         version: 18.19.68
-      mdast-util-mdx-jsx:
-        specifier: ^3.1.3
-        version: 3.1.3
       remark-custom-heading-id:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1798,6 +1798,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.8
+      napi-wasm: 1.1.3
     bundledDependencies:
       - napi-wasm
 
@@ -2050,6 +2051,7 @@ packages:
     resolution: {integrity: sha512-pvQ+TKeRHeiUGRhvYwRrQ/ISnohKkSJR14fT2yqyZ4e9K5vqc7hrtY2Y1Dw0ZwAzQ6DQsxsaCUuSIIi8v0Cq6w==}
     dependencies:
       '@types/estree': 1.0.6
+    dev: false
 
   /@types/estree@1.0.6:
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -2945,6 +2947,7 @@ packages:
 
   /character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+    dev: false
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
@@ -4621,12 +4624,14 @@ packages:
 
   /is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+    dev: false
 
   /is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
     dependencies:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
+    dev: false
 
   /is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -4716,6 +4721,7 @@ packages:
 
   /is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+    dev: false
 
   /is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -4752,6 +4758,7 @@ packages:
 
   /is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+    dev: false
 
   /is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -5277,6 +5284,7 @@ packages:
       vfile-message: 4.0.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /mdast-util-mdx@3.0.0:
     resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
@@ -5731,6 +5739,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /napi-wasm@1.1.3:
+    resolution: {integrity: sha512-h/4nMGsHjZDCYmQVNODIrYACVJ+I9KItbG+0si6W/jSjdA9JbWDoU4LLeMXVcEQGHjttI2tuXqDrbGF7qkUHHg==}
+
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
@@ -5988,6 +5999,7 @@ packages:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+    dev: false
 
   /parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

Hi :wave:

Following https://github.com/HiDeoo/starlight-openapi/pull/73, I directly opened a PR for a similar fix here.

**Why**

https://github.com/HiDeoo/starlight-links-validator/blob/16e88ab1a463cbbe84741fb487d90032392dc2e3/packages/starlight-links-validator/libs/remark.ts#L1 imports `mdast-util-mdx-jsx`, which isn't made available if it is only a devDep.

**How**

How were these changes implemented?

**Screenshots**

If applicable, add screenshots to help explain what is being modified.

<!-- Feel free to add additional comments. -->
