### PR TITLE
fix: redirect validation with a base and under the Bun runtime

### DIFF
--- a/.changeset/tidy-donkeys-shave.md
+++ b/.changeset/tidy-donkeys-shave.md
@@ -1,0 +1,8 @@
+---
+'starlight-links-validator': patch
+---
+
+Fixes redirect validation with a custom `base` and a crash when building with the Bun runtime.
+
+Redirect routes were recorded without the `base` prefix while links are validated with it, so a link to a redirect was reported as invalid in a project setting the `base` Astro option.
+Resolving the base also relied on `import.meta.env.BASE_URL`, which is `process.env.BASE_URL` under Bun and therefore `undefined`, crashing the build with `undefined is not an object (evaluating 'path.replace')` as soon as a project defined any redirect.

--- a/.changeset/tidy-donkeys-shave.md
+++ b/.changeset/tidy-donkeys-shave.md
@@ -2,7 +2,4 @@
 'starlight-links-validator': patch
 ---
 
-Fixes redirect validation with a custom `base` and a crash when building with the Bun runtime.
-
-Redirect routes were recorded without the `base` prefix while links are validated with it, so a link to a redirect was reported as invalid in a project setting the `base` Astro option.
-Resolving the base also relied on `import.meta.env.BASE_URL`, which is `process.env.BASE_URL` under Bun and therefore `undefined`, crashing the build with `undefined is not an object (evaluating 'path.replace')` as soon as a project defined any redirect.
+Fixes a validation issue with Astro redirects when the `base` option is configured.

--- a/.changeset/tidy-insects-yawn.md
+++ b/.changeset/tidy-insects-yawn.md
@@ -1,0 +1,5 @@
+---
+'starlight-links-validator': patch
+---
+
+Fixes a validation issue when using Bun.

--- a/packages/starlight-links-validator/index.ts
+++ b/packages/starlight-links-validator/index.ts
@@ -70,7 +70,12 @@ export default function starlightLinksValidatorPlugin(
                 if (route?.origin !== 'project') continue
 
                 for (const url of urls) {
-                  const routeKey = pathnameToSlug(url.pathname.replace(astroConfig.outDir.pathname, ''))
+                  const routeKey = stripTrailingSlash(
+                    normalizePathname(
+                      pathnameToSlug(url.pathname.replace(astroConfig.outDir.pathname, '')),
+                      astroConfig.base,
+                    ),
+                  )
 
                   if (route.type !== 'redirect' || !route.redirect || !route.pathname) {
                     projectRoutes.set(routeKey, { type: 'custom-page' })

--- a/packages/starlight-links-validator/index.ts
+++ b/packages/starlight-links-validator/index.ts
@@ -9,7 +9,7 @@ import {
 } from './libs/config'
 import { throwPluginError } from './libs/error'
 import { isAbsoluteUrl } from './libs/link'
-import { normalizePathname, pathnameToSlug, stripTrailingSlash } from './libs/path'
+import { normalizePathname, normalizePathnameWithBase, pathnameToSlug, stripTrailingSlash } from './libs/path'
 import { applyMarkdownPlugin } from './libs/processor'
 import { clearValidationData, setValidationConfig } from './libs/store'
 import { validateLinks, type ProjectRoutes } from './libs/validation'
@@ -71,7 +71,7 @@ export default function starlightLinksValidatorPlugin(
 
                 for (const url of urls) {
                   const routeKey = stripTrailingSlash(
-                    normalizePathname(
+                    normalizePathnameWithBase(
                       pathnameToSlug(url.pathname.replace(astroConfig.outDir.pathname, '')),
                       astroConfig.base,
                     ),
@@ -91,7 +91,7 @@ export default function starlightLinksValidatorPlugin(
 
                   projectRoutes.set(routeKey, {
                     type: 'redirect-internal',
-                    path: normalizePathname(destination, astroConfig.base),
+                    path: normalizePathname(destination),
                   })
                 }
               }

--- a/packages/starlight-links-validator/libs/i18n.ts
+++ b/packages/starlight-links-validator/libs/i18n.ts
@@ -1,4 +1,4 @@
-import { ensureLeadingSlash, ensureTrailingSlash, stripLeadingSlash } from './path'
+import { ensureLeadingSlash, ensureTrailingSlash, normalizePathname } from './path'
 import type { ValidationData } from './store'
 import type { StarlightUserConfig } from './validation'
 
@@ -37,7 +37,7 @@ export function getFallbackHeadings(
   if (!localeConfig) return
 
   const isPathWithBase = base !== '/'
-  const normalizedBase = isPathWithBase ? ensureTrailingSlash(stripLeadingSlash(base)) : ''
+  const normalizedBase = isPathWithBase ? normalizePathname(base) : ''
   const normalizedPath = isPathWithBase ? path.replace(normalizedBase, '') : path
 
   for (const locale of localeConfig.locales) {

--- a/packages/starlight-links-validator/libs/path.ts
+++ b/packages/starlight-links-validator/libs/path.ts
@@ -33,6 +33,10 @@ export function pathnameToSlug(pathname: string): string {
   return segments.filter(Boolean).join('/')
 }
 
-export function normalizePathname(pathname: string, base: string) {
-  return ensureTrailingSlash(base === '/' ? stripLeadingSlash(pathname) : posix.join(stripLeadingSlash(base), pathname))
+export function normalizePathname(pathname: string) {
+  return ensureTrailingSlash(stripLeadingSlash(pathname))
+}
+
+export function normalizePathnameWithBase(pathname: string, base: string) {
+  return normalizePathname(base === '/' ? pathname : posix.join(stripLeadingSlash(base), pathname))
 }

--- a/packages/starlight-links-validator/libs/path.ts
+++ b/packages/starlight-links-validator/libs/path.ts
@@ -19,12 +19,6 @@ export function stripTrailingSlash(path: string) {
 }
 
 export function pathnameToSlug(pathname: string): string {
-  const base = stripTrailingSlash(import.meta.env.BASE_URL)
-
-  if (pathname.startsWith(base)) {
-    pathname = pathname.replace(base, '')
-  }
-
   const segments = pathname.split('/')
 
   if (segments.at(-1) === 'index.html') {

--- a/packages/starlight-links-validator/libs/validation.ts
+++ b/packages/starlight-links-validator/libs/validation.ts
@@ -11,7 +11,7 @@ import type { ValidationReport, ValidationReportIssue } from '../reporters'
 
 import { getFallbackHeadings, getLocaleConfig, isInconsistentLocaleLink, type LocaleConfig } from './i18n'
 import type { Link } from './link'
-import { ensureTrailingSlash, normalizePathname, stripLeadingSlash, stripTrailingSlash } from './path'
+import { normalizePathname, normalizePathnameWithBase, stripLeadingSlash, stripTrailingSlash } from './path'
 import { getErrorPosition, isSameLineSourcePosition, type Reference } from './position'
 import { getValidationData, type ValidationData } from './store'
 
@@ -75,7 +75,7 @@ export async function validateLinks(
 ): Promise<ValidationReport> {
   const localeConfig = getLocaleConfig(starlightConfig)
   const validationData = getValidationData()
-  const allPages: Pages = new Set(pages.map((page) => normalizePathname(page.pathname, astroConfig.base)))
+  const allPages: Pages = new Set(pages.map((page) => normalizePathnameWithBase(page.pathname, astroConfig.base)))
 
   const issues: ValidationContext['issues'] = new Map()
 
@@ -176,7 +176,7 @@ function validateLink(context: ValidationContext) {
     return
   }
 
-  const sanitizedPath = ensureTrailingSlash(stripQueryString(path))
+  const sanitizedPath = normalizePathname(stripQueryString(path))
 
   const isValidPage = pages.has(sanitizedPath)
   let fileHeadings = getFileHeadings(sanitizedPath, context)

--- a/packages/starlight-links-validator/middleware.ts
+++ b/packages/starlight-links-validator/middleware.ts
@@ -2,7 +2,7 @@ import { defineRouteMiddleware, type StarlightRouteData } from '@astrojs/starlig
 
 import { isFrontmatterWithHeroActions, isFrontmatterPrevNextLink } from './libs/frontmatter'
 import { getLinkToValidate } from './libs/link'
-import { ensureTrailingSlash, stripLeadingSlash } from './libs/path'
+import { normalizePathname } from './libs/path'
 import { getFrontmatterReference, type FrontmatterReference } from './libs/position'
 import { getValidationConfig, updateFrontmatterLink } from './libs/store'
 
@@ -15,7 +15,7 @@ export const onRequest = defineRouteMiddleware(async (context, next) => {
   const config = getValidationConfig()
   if (!config) return
 
-  const id = ensureTrailingSlash(stripLeadingSlash(context.url.pathname))
+  const id = normalizePathname(context.url.pathname)
   const after = getFrontmatterLinks(context.locals.starlightRoute.entry.data)
 
   for (const [key, { link, path }] of after) {

--- a/packages/starlight-links-validator/tests/base-path.test.ts
+++ b/packages/starlight-links-validator/tests/base-path.test.ts
@@ -9,11 +9,14 @@ test('validates links when the `base` Astro option is set', async () => {
 
   expect(status).toBe('error')
 
-  expectValidationErrorCount(output, 31, 4)
+  expectValidationErrorCount(output, 34, 4)
 
   expectValidationErrors(output, 'redirects.md', [
-    ['/test/redirect-test/#unknown', ValidationErrorType.InvalidHash, 6],
-    ['/test/redirect-unknown/', ValidationErrorType.InvalidLink, 7],
+    ['/test/redirect-test/#unknown', ValidationErrorType.InvalidHash, 9],
+    ['/test/redirect-unknown/', ValidationErrorType.InvalidLink, 10],
+    ['/redirect-external/', ValidationErrorType.InvalidLink, 12],
+    ['/redirect-test/', ValidationErrorType.InvalidLink, 13],
+    ['/redirect-test/#description', ValidationErrorType.InvalidLink, 14],
   ])
 
   expectValidationErrors(output, 'test.md', [

--- a/packages/starlight-links-validator/tests/base-path.test.ts
+++ b/packages/starlight-links-validator/tests/base-path.test.ts
@@ -9,7 +9,12 @@ test('validates links when the `base` Astro option is set', async () => {
 
   expect(status).toBe('error')
 
-  expectValidationErrorCount(output, 29, 3)
+  expectValidationErrorCount(output, 31, 4)
+
+  expectValidationErrors(output, 'redirects.md', [
+    ['/test/redirect-test/#unknown', ValidationErrorType.InvalidHash, 6],
+    ['/test/redirect-unknown/', ValidationErrorType.InvalidLink, 7],
+  ])
 
   expectValidationErrors(output, 'test.md', [
     ['/guides/example', ValidationErrorType.InvalidLink, 15],

--- a/packages/starlight-links-validator/tests/fixtures/base-path/astro.config.ts
+++ b/packages/starlight-links-validator/tests/fixtures/base-path/astro.config.ts
@@ -34,8 +34,8 @@ export default defineConfig({
     }),
   },
   redirects: {
-    '/redirect-test/': '/guides/example/',
-    '/redirect-unknown/': '/unknown/',
+    '/redirect-external/': 'https://starlight.astro.build/',
+    '/redirect-test/': `${base}/guides/example/`,
   },
   site: 'https://example.com',
 })

--- a/packages/starlight-links-validator/tests/fixtures/base-path/astro.config.ts
+++ b/packages/starlight-links-validator/tests/fixtures/base-path/astro.config.ts
@@ -33,6 +33,10 @@ export default defineConfig({
       },
     }),
   },
+  redirects: {
+    '/redirect-test/': '/guides/example/',
+    '/redirect-unknown/': '/unknown/',
+  },
   site: 'https://example.com',
 })
 

--- a/packages/starlight-links-validator/tests/fixtures/base-path/src/content/docs/redirects.md
+++ b/packages/starlight-links-validator/tests/fixtures/base-path/src/content/docs/redirects.md
@@ -1,0 +1,7 @@
+---
+title: Redirects
+---
+
+- [Link to static internal redirect](/test/redirect-test/)
+- [Link to static internal redirect with invalid hash](/test/redirect-test/#unknown)
+- [Link to unknown static internal redirect](/test/redirect-unknown/)

--- a/packages/starlight-links-validator/tests/fixtures/base-path/src/content/docs/redirects.md
+++ b/packages/starlight-links-validator/tests/fixtures/base-path/src/content/docs/redirects.md
@@ -2,6 +2,13 @@
 title: Redirects
 ---
 
+- [Link to static external redirect](/test/redirect-external/)
 - [Link to static internal redirect](/test/redirect-test/)
+- [Link to static internal redirect with hash](/test/redirect-test/#description)
+
 - [Link to static internal redirect with invalid hash](/test/redirect-test/#unknown)
 - [Link to unknown static internal redirect](/test/redirect-unknown/)
+
+- [Link to static external redirect with missing base](/redirect-external/)
+- [Link to static internal redirect with missing base](/redirect-test/)
+- [Link to static internal redirect with hash and missing base](/redirect-test/#description)


### PR DESCRIPTION
Redirect routes were recorded under a key without the `base` prefix, while links are validated with it, so any link to a redirect was reported as an invalid link in a project that sets the `base` Astro option.

Resolving the base also went through `import.meta.env.BASE_URL` inside `pathnameToSlug()`. That value is injected by Vite, but the plugin runs in the Astro process: under Bun `import.meta.env` is `process.env`, where `BASE_URL` is undefined, so `stripTrailingSlash(undefined)` threw "undefined is not an object (evaluating 'path.replace')" and failed the build of any project defining a redirect.

Derive the route key from the emitted file path and apply the base with `normalizePathname()`, the same helper already used for redirect destinations, so both sides of the lookup agree. `pathnameToSlug()` is now purely a file-path-to-slug conversion and no longer reads `import.meta.env`.

Cover both with redirects in the `base-path` fixture: a link to a redirect now resolves to its destination, its hash is validated against the destination page, and a redirect to an unknown page is still reported.